### PR TITLE
chore: make renovate update major versions only

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -22,7 +22,7 @@
         "pin",
         "digest"
       ],
-      "automerge": true
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
As there is no CI, as such, for this repo it doesn't make sense to have such frequent changes that can't be easily tested.  

Updating major versions is more relevant, as suggested in https://github.com/pactflow/katacoda-workshops/pull/26