### PR TITLE
Renovate/openjdk

### DIFF
--- a/pactflow-getting-started-java/intro-start.sh
+++ b/pactflow-getting-started-java/intro-start.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-echo "Installing OpenJDK 17 for consumer"
+echo "Installing OpenJDK 17 for consumer and provider"
 mkdir -p /usr/java
 cd /usr/java
 wget -c https://download.java.net/java/GA/jdk17.0.2/dfd4a8d0985749f896bed50d7138ee7f/8/GPL/openjdk-17.0.2_linux-x64_bin.tar.gz
@@ -7,10 +7,5 @@ tar -xf openjdk-17.0.2_linux-x64_bin.tar.gz
 echo 'export JAVA_HOME=/usr/java/jdk-17.0.2' >> ~/.bashrc
 echo "export PATH=/usr/java/jdk-17.0.2/bin:${PATH}" >> ~/.bashrc
 source ~/.bashrc
-echo "Installing OpenJDK 17 for provider"
-mkdir -p /usr/java
-cd /usr/java
-wget -c https://download.java.net/java/GA/jdk17.0.2/dfd4a8d0985749f896bed50d7138ee7f/8/GPL/openjdk-17.0.2_linux-x64_bin.tar.gz
-tar -xf openjdk-17.0.2_linux-x64_bin.tar.gz
 echo "Installing jq"
 apt --yes install jq && cd ~ && clear && echo "Welcome to the PactFlow Tutorial, all the dependencies are installed, and you should be good to go!"

--- a/pactflow-getting-started-java/intro-start.sh
+++ b/pactflow-getting-started-java/intro-start.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
-echo "Installing OpenJDK 24 for consumer"
+echo "Installing OpenJDK 17 for consumer"
 mkdir -p /usr/java
 cd /usr/java
-wget -c https://download.java.net/java/GA/jdk24.0.2/fdc5d0102fe0414db21410ad5834341f/12/GPL/openjdk-24.0.2_linux-x64_bin.tar.gz
-tar -xf openjdk-24.0.2_linux-x64_bin.tar.gz
-echo 'export JAVA_HOME=/usr/java/jdk-24.0.2' >> ~/.bashrc
-echo "export PATH=/usr/java/jdk-24.0.2/bin:${PATH}" >> ~/.bashrc
+wget -c https://download.java.net/java/GA/jdk17.0.2/dfd4a8d0985749f896bed50d7138ee7f/8/GPL/openjdk-17.0.2_linux-x64_bin.tar.gz
+tar -xf openjdk-17.0.2_linux-x64_bin.tar.gz
+echo 'export JAVA_HOME=/usr/java/jdk-17.0.2' >> ~/.bashrc
+echo "export PATH=/usr/java/jdk-17.0.2/bin:${PATH}" >> ~/.bashrc
 source ~/.bashrc
-echo "Installing OpenJDK 11 for provider"
+echo "Installing OpenJDK 17 for provider"
 mkdir -p /usr/java
 cd /usr/java
-wget -c https://download.java.net/java/ga/jdk11/openjdk-11_linux-x64_bin.tar.gz
-tar -xf openjdk-11_linux-x64_bin.tar.gz
+wget -c https://download.java.net/java/GA/jdk17.0.2/dfd4a8d0985749f896bed50d7138ee7f/8/GPL/openjdk-17.0.2_linux-x64_bin.tar.gz
+tar -xf openjdk-17.0.2_linux-x64_bin.tar.gz
 echo "Installing jq"
 apt --yes install jq && cd ~ && clear && echo "Welcome to the PactFlow Tutorial, all the dependencies are installed, and you should be good to go!"

--- a/pactflow-getting-started-java/intro-start.sh
+++ b/pactflow-getting-started-java/intro-start.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
-echo "Installing OpenJDK 15 for consumer"
+echo "Installing OpenJDK 24 for consumer"
 mkdir -p /usr/java
 cd /usr/java
-wget -c https://download.java.net/java/GA/jdk15.0.2/0d1cfde4252546c6931946de8db48ee2/7/GPL/openjdk-15.0.2_linux-x64_bin.tar.gz
-tar -xf openjdk-15.0.2_linux-x64_bin.tar.gz
-echo 'export JAVA_HOME=/usr/java/jdk-15.0.2' >> ~/.bashrc
-echo "export PATH=/usr/java/jdk-15.0.2/bin:${PATH}" >> ~/.bashrc
+wget -c https://download.java.net/java/GA/jdk24.0.2/fdc5d0102fe0414db21410ad5834341f/12/GPL/openjdk-24.0.2_linux-x64_bin.tar.gz
+tar -xf openjdk-24.0.2_linux-x64_bin.tar.gz
+echo 'export JAVA_HOME=/usr/java/jdk-24.0.2' >> ~/.bashrc
+echo "export PATH=/usr/java/jdk-24.0.2/bin:${PATH}" >> ~/.bashrc
 source ~/.bashrc
 echo "Installing OpenJDK 11 for provider"
 mkdir -p /usr/java


### PR DESCRIPTION
For the killacode tutorials the gradle builds now require jdk 17 or higher. 